### PR TITLE
Add ReachabilityAppBarLayout state continuity

### DIFF
--- a/app/src/main/java/space/narrate/waylan/android/AppNavigator.kt
+++ b/app/src/main/java/space/narrate/waylan/android/AppNavigator.kt
@@ -17,6 +17,8 @@ import space.narrate.waylan.core.ui.Navigator
 import space.narrate.waylan.core.ui.Navigator.BackType.DRAG
 import space.narrate.waylan.core.ui.Navigator.BackType.ICON
 import space.narrate.waylan.core.ui.common.Event
+import space.narrate.waylan.core.ui.widget.ReachabilityAppBarLayout
+import space.narrate.waylan.core.ui.widget.ReachabilityAppBarLayout.*
 
 class AppNavigator(
     private val analyticsRepository: AnalyticsRepository
@@ -30,8 +32,16 @@ class AppNavigator(
     override val shouldNavigateBack: LiveData<Event<Boolean>>
         get() = _shouldNavigateBack
 
+    private val _reachabilityState: MutableLiveData<ReachableContinuityNavigator.State> = MutableLiveData()
+    override val reachabilityState: LiveData<ReachableContinuityNavigator.State>
+        get() = _reachabilityState
+
     override fun setCurrentDestination(dest: NavDestination, arguments: Bundle?) {
         _currentDestination.value = fromDestinationId(dest, arguments)
+    }
+
+    override fun setReachabilityState(state: ReachableContinuityNavigator.State) {
+        _reachabilityState.value = state
     }
 
     override fun toBack(backType: Navigator.BackType, from: String): Boolean {

--- a/core/src/main/java/space/narrate/waylan/core/ui/Navigator.kt
+++ b/core/src/main/java/space/narrate/waylan/core/ui/Navigator.kt
@@ -6,8 +6,9 @@ import android.os.Bundle
 import androidx.lifecycle.LiveData
 import androidx.navigation.NavDestination
 import space.narrate.waylan.core.ui.common.Event
+import space.narrate.waylan.core.ui.widget.ReachabilityAppBarLayout
 
-interface Navigator {
+interface Navigator : ReachabilityAppBarLayout.ReachableContinuityNavigator {
 
     enum class BackType {
         ICON, DRAG

--- a/core/src/main/java/space/narrate/waylan/core/ui/widget/ReachabilityAppBarLayout.kt
+++ b/core/src/main/java/space/narrate/waylan/core/ui/widget/ReachabilityAppBarLayout.kt
@@ -206,7 +206,10 @@ class ReachabilityAppBarLayout @JvmOverloads constructor(
      * A convenience method to allow lifecycleOwners which use a ReachabilityAppBar to setup
      * and react to changes in other ReachabilityAppBars.
      */
-    fun setReachableContinuityNavigator(lifecycleOwner: LifecycleOwner, navigator: ReachableContinuityNavigator) {
+    fun setReachableContinuityNavigator(
+        lifecycleOwner: LifecycleOwner,
+        navigator: ReachableContinuityNavigator
+    ) {
         this.reachableContinuityNavigator = navigator
         navigator.reachabilityState.observe(lifecycleOwner) { state ->
             if (state.id != id) setExpanded(state.expanded, false)

--- a/settings/src/main/java/space/narrate/waylan/settings/ui/about/AboutFragment.kt
+++ b/settings/src/main/java/space/narrate/waylan/settings/ui/about/AboutFragment.kt
@@ -6,7 +6,9 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
+import androidx.lifecycle.observe
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import org.koin.android.ext.android.inject
 import space.narrate.waylan.core.ui.Navigator
 import space.narrate.waylan.core.ui.common.BaseFragment
@@ -60,6 +62,8 @@ class AboutFragment: BaseFragment() {
             appBar.setOnNavigationIconClicked {
                 navigator.toBack(Navigator.BackType.ICON, this.javaClass.simpleName)
             }
+
+            appBar.setReachableContinuityNavigator(this@AboutFragment, navigator)
 
             // Version preference
             versionPreference.setDesc("v${BuildConfig.VERSION_NAME} • ${BuildConfig.BUILD_TYPE}")

--- a/settings/src/main/java/space/narrate/waylan/settings/ui/developer/DeveloperSettingsFragment.kt
+++ b/settings/src/main/java/space/narrate/waylan/settings/ui/developer/DeveloperSettingsFragment.kt
@@ -64,12 +64,6 @@ class DeveloperSettingsFragment : BaseFragment() {
         super.onViewCreated(view, savedInstanceState)
 
         binding.run {
-//            appBar.setUpWithElasticBehavior(
-//                this.javaClass.simpleName,
-//                navigator,
-//                listOf(navigationIcon),
-//                listOf(scrollView, appBar)
-//            )
 
             appBar.doOnElasticDrag(
                 alphaViews = listOf(scrollView, appBar)
@@ -82,6 +76,8 @@ class DeveloperSettingsFragment : BaseFragment() {
             appBar.setOnNavigationIconClicked {
                 navigator.toBack(Navigator.BackType.ICON, this.javaClass.simpleName)
             }
+
+            appBar.setReachableContinuityNavigator(this@DeveloperSettingsFragment, navigator)
 
             viewModel.shouldShowSnackbar.observe(this@DeveloperSettingsFragment) { event ->
                 event.getUnhandledContent()?.let { showSnackbar(it) }

--- a/settings/src/main/java/space/narrate/waylan/settings/ui/settings/SettingsFragment.kt
+++ b/settings/src/main/java/space/narrate/waylan/settings/ui/settings/SettingsFragment.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import androidx.lifecycle.observe
+import androidx.navigation.NavArgumentBuilder
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.Snackbar
 import org.koin.android.ext.android.inject
@@ -23,6 +24,7 @@ import space.narrate.waylan.core.util.visible
 import space.narrate.waylan.settings.BuildConfig
 import space.narrate.waylan.settings.R
 import space.narrate.waylan.settings.databinding.FragmentSettingsBinding
+import space.narrate.waylan.settings.ui.about.AboutFragmentDirections
 import space.narrate.waylan.settings.ui.dialog.RadioGroupAlertDialog
 
 /**
@@ -99,6 +101,8 @@ class SettingsFragment : BaseFragment() {
             appBar.setOnNavigationIconClicked {
                 navigator.toBack(Navigator.BackType.ICON, this.javaClass.simpleName)
             }
+
+            appBar.setReachableContinuityNavigator(this@SettingsFragment, navigator)
 
             setUpBanner()
 

--- a/settings/src/main/java/space/narrate/waylan/settings/ui/thirdparty/ThirdPartyLibrariesFragment.kt
+++ b/settings/src/main/java/space/narrate/waylan/settings/ui/thirdparty/ThirdPartyLibrariesFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
+import androidx.lifecycle.observe
 import androidx.recyclerview.widget.LinearLayoutManager
 import org.koin.android.ext.android.inject
 import org.koin.android.viewmodel.ext.android.viewModel
@@ -61,6 +62,8 @@ class ThirdPartyLibrariesFragment : BaseFragment(), ThirdPartyLibraryAdapter.Lis
             appBar.setOnNavigationIconClicked {
                 navigator.toBack(Navigator.BackType.ICON, this.javaClass.simpleName)
             }
+
+            appBar.setReachableContinuityNavigator(this@ThirdPartyLibrariesFragment, navigator)
         }
 
         setUpList()


### PR DESCRIPTION
The expanded/collapsed state of a reachable app bar is persisted between instances of an app bar on different screens.