### PR TITLE
Fix firestore user add-on migration errors

### DIFF
--- a/app/src/main/java/space/narrate/waylan/android/ui/details/DetailsViewModel.kt
+++ b/app/src/main/java/space/narrate/waylan/android/ui/details/DetailsViewModel.kt
@@ -4,7 +4,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import space.narrate.waylan.core.data.firestore.users.AddOn
+import space.narrate.waylan.core.data.firestore.users.AddOnState
 import space.narrate.waylan.core.data.firestore.users.isValid
+import space.narrate.waylan.core.data.firestore.users.state
 import space.narrate.waylan.core.details.DetailDataProviderRegistry
 import space.narrate.waylan.core.details.DetailItemModel
 import space.narrate.waylan.core.details.DetailItemType
@@ -36,7 +38,8 @@ class DetailsViewModel(
         .mapOnTransform(userRepository.getUserAddOnsLive()) { list, addOns ->
             val filteredList = list.toMutableList()
             addOns.forEach { addOn ->
-                if (!addOn.isValid && addOn.isAwareOfExpiration) {
+                if (addOn.state == AddOnState.NONE ||
+                    (!addOn.isValid && addOn.isAwareOfExpiration)) {
                     filteredList.removeAll {
                         // Map UserAddOn to a DetailItemType
                         val type = when (AddOn.fromId(addOn.id)) {

--- a/core/src/main/java/space/narrate/waylan/core/data/firestore/FirestoreStore.kt
+++ b/core/src/main/java/space/narrate/waylan/core/data/firestore/FirestoreStore.kt
@@ -163,11 +163,16 @@ class FirestoreStore(
 
                 // Transfer legacy User properties which kept track of Merriam-Webster purchases
                 // over to the new UserAddOn document.
-                if (addOn == AddOn.MERRIAM_WEBSTER && user.merriamWebsterPurchaseToken.isNotBlank()) {
+                if (addOn == AddOn.MERRIAM_WEBSTER) {
                     userAddOn.apply {
                         started = user.merriamWebsterStarted
+                        hasStartedFreeTrial = true
                         purchaseToken = user.merriamWebsterPurchaseToken
-                        validDurationDays = 365L
+                        validDurationDays = when {
+                            user.merriamWebsterPurchaseToken.isNotBlank() -> 365L
+                            !user.isAnonymous -> 30L
+                            else -> 7L
+                        }
                         isAwareOfExpiration = false
                     }
                 }


### PR DESCRIPTION
- Fixed Migrating Merriam-Webster User-level add-on/plugin fields to a UserAddOn document error.
- Fixed AddOnState.NONE detail items from showing in definitions 