### PR TITLE
:merraimwebster_thesaurus card hide expand collapse when empty

### DIFF
--- a/app/src/main/java/space/narrate/waylan/android/ui/details/DetailItemListMediatorLiveData.kt
+++ b/app/src/main/java/space/narrate/waylan/android/ui/details/DetailItemListMediatorLiveData.kt
@@ -106,6 +106,6 @@ class DetailItemListMediatorLiveData : MediatorLiveData<List<DetailItemModel>>()
     }
 
     companion object {
-        private const val INITIAL_POST_DELAY_MILLIS = 250L
+        private const val INITIAL_POST_DELAY_MILLIS = 400L // Originally 250L
     }
 }

--- a/app/src/main/java/space/narrate/waylan/android/ui/details/DetailItemListMediatorLiveData.kt
+++ b/app/src/main/java/space/narrate/waylan/android/ui/details/DetailItemListMediatorLiveData.kt
@@ -106,6 +106,6 @@ class DetailItemListMediatorLiveData : MediatorLiveData<List<DetailItemModel>>()
     }
 
     companion object {
-        private const val INITIAL_POST_DELAY_MILLIS = 400L // Originally 250L
+        private const val INITIAL_POST_DELAY_MILLIS = 400L
     }
 }

--- a/merriamwebster_thesaurus/src/main/java/space/narrate/waylan/merriamwebster_thesaurus/ui/MerriamWebsterThesaurusCardView.kt
+++ b/merriamwebster_thesaurus/src/main/java/space/narrate/waylan/merriamwebster_thesaurus/ui/MerriamWebsterThesaurusCardView.kt
@@ -116,6 +116,10 @@ class MerriamWebsterThesaurusCardView @JvmOverloads constructor(
                 .flatten()
                 .take(if (collapsed) COLLAPSED_MAX_ANTONYMS else Integer.MAX_VALUE)
         )
+
+        // Hide the expand/collapse button if there is not content from MW Thesaurus.
+        expandCollapseButton.visibility =
+            if (listContainer.childCount == 0) View.GONE else View.VISIBLE
     }
 
     /**


### PR DESCRIPTION
- Hide empty thesaurus card expand/collapse button
- Increase delay to show details item list to make a smoother initial adapter load animation