### PR TITLE
Fix Android 11 keyboard height bugs

### DIFF
--- a/app/src/main/java/space/narrate/waylan/android/util/KeyboardManager.kt
+++ b/app/src/main/java/space/narrate/waylan/android/util/KeyboardManager.kt
@@ -14,7 +14,6 @@ import android.widget.FrameLayout
 import android.widget.PopupWindow
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
-import androidx.core.view.ViewCompat
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver

--- a/app/src/main/java/space/narrate/waylan/android/util/KeyboardManager.kt
+++ b/app/src/main/java/space/narrate/waylan/android/util/KeyboardManager.kt
@@ -14,6 +14,7 @@ import android.widget.FrameLayout
 import android.widget.PopupWindow
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
@@ -82,6 +83,15 @@ class KeyboardManager(
                     handleWindowInsetsAnimationProgress(insets)
                     return insets
                 }
+
+                override fun onEnd(animation: WindowInsetsAnimation) {
+                    super.onEnd(animation)
+                    // If the ime animation has been interrupted by an app exit or other event,
+                    // make sure to update the keyboard height to the end value and avoid getting
+                    // stuck midway through the animation.
+                    val insets = targetView.rootWindowInsets
+                    handleWindowInsetsAnimationProgress(insets)
+                }
             }
             targetView.setWindowInsetsAnimationCallback(cb)
         } else {
@@ -142,7 +152,7 @@ class KeyboardManager(
     @RequiresApi(Build.VERSION_CODES.R)
     private fun handleWindowInsetsAnimationProgress(insets: WindowInsets) {
         val nonImeInsetBottom = insets
-            .getInsets(WindowInsets.Type.systemGestures())
+            .getInsets(WindowInsets.Type.navigationBars())
             .bottom
         val imeInsetBottom = insets.getInsets(WindowInsets.Type.ime()).bottom
         // Subtract any insets that are protecting the navigation area


### PR DESCRIPTION
* Update to use navigationBar insets to subtract from the keyboard height inset to isolate the ime height on both android 10 and android 11
* Update to calculate the keyboard height when the ime animation ends in order to capture the height if the animation is interrupted/cancelled